### PR TITLE
Add option to display camera preview on dashboard (enabled by default)

### DIFF
--- a/css/dark_theme.css
+++ b/css/dark_theme.css
@@ -75,3 +75,8 @@ header.logo {
 #bigtext, .switch-cell {
   background: linear-gradient(to right, rgba(81,85,88, 0), rgba(81,85,88, 1) 15px) !important;
 }
+
+#holder .row .item table[id^="item"] > tbody > tr.with-cam-preview > #name {
+  background: rgba(0,0, 0, 0.2) !important;
+}
+

--- a/css/dashboard_camera.css
+++ b/css/dashboard_camera.css
@@ -1,0 +1,9 @@
+#holder .row .item table[id^="item"] > tbody > tr.with-cam-preview {
+    background-size: cover;
+    background-position: center;
+}
+#holder .row .item table[id^="item"] > tbody > tr.with-cam-preview > #name {
+    background: rgba(255,255, 255, 0.2);
+    border-bottom-right-radius: 5px;
+    width: 100%;
+}

--- a/custom.css
+++ b/custom.css
@@ -369,7 +369,7 @@ div.bannercontent .row.divider{
   grid-template-areas:
     'name name bigtext bigtext bigtext options'
     'img img2 status status status status'
-    'lastupdate lastupdate lastupdate lastupdate tools tools'
+    'lastupdate lastupdate lastupdate lastupdate tools tools';
 }
 #holder #dashcontent .row .item table[id^="item"] > tbody > tr {
   grid-template-rows: 40px minmax(0,1fr) 0;

--- a/js/functions.js
+++ b/js/functions.js
@@ -128,7 +128,7 @@ function applySwitchersAndSubmenus() {
 				$(this).find('.options').append('<a class="btnsmall" id="idno"><i>Idx: ' + itemID + '</i></a>');
 			}
             removeEmptySectionDashboard();
-		}
+        }
 		// options to not have switch instaed of bigText on scene devices
 		let switchOnScenes = false;
 		let switchOnScenesDash = false;
@@ -171,6 +171,22 @@ function applySwitchersAndSubmenus() {
 			}
 		}
 	});
+    /* Feature - Display camera preview on dashboard */
+    if (theme.features.dashboard_camera.enabled === true){
+        $('#bigtext > span > a').each(function() {
+            camId = $(this).attr('href').split(/\'/)[3];
+            if ($(this).parents('tr.with-cam-preview').length == 0) {
+                $(this).parents('tr').attr('data-cam', camId).append('<td><img id="preview-cam' + camId + '"></td>');
+                $(this).parents('tr').attr('data-cam', camId).addClass('with-cam-preview').on('click', function(e) {
+                    ShowCameraLiveStream('Camera', $(this).attr('data-cam'));
+                }).children('td:not(#name)').hide();
+            }
+            // Prevent flickering by preloading img first
+            $('#preview-cam' + camId).attr('src', 'camsnapshot.jpg?idx=' + camId + '?t=' +  Date.now()).on('load', function() {  
+                $(this).parents('tr').css('background-image', 'url(' + $(this).attr('src') + ')');
+            });
+        });
+    }
     /* Set autoscroll for long status or hide empty status */
     $("#status", "tr").not(".scroll").each(function() {
         var html = $(this).html();

--- a/theme.json
+++ b/theme.json
@@ -91,6 +91,11 @@
             "id":30,
             "enabled":false,
             "files": ["dashboard_columns.css"]
+        },
+    "dashboard_camera": {
+            "id":31,
+            "enabled":false,
+            "files": ["dashboard_camera.css"]
         }
     }
 }

--- a/theme.json
+++ b/theme.json
@@ -94,7 +94,7 @@
         },
     "dashboard_camera": {
             "id":31,
-            "enabled":false,
+            "enabled":true,
             "files": ["dashboard_camera.css"]
         }
     }

--- a/themesettings.html
+++ b/themesettings.html
@@ -29,7 +29,9 @@
             <p><input id="themevar20" class="parentrequired" name="themevar20" value="switch_instead_of_bigtext" type="checkbox"><label for="themevar20" data-i18n="Switch Instead of Text"> Switch Instead of Text</label><br/>
             <input id="themevar22" class="parentrequiredchild" name="themevar22" value="switch_instead_of_bigtext_scenes" type="checkbox"><label for="themevar22" data-i18n="Scene Devices">Scene Devices</label></p>
             <input id="themevar21" name="themevar21" value="dashboard_show_last_update" type="checkbox"><label for="themevar21" data-i18n="Show last seen"> Show Last Seen On Dashboard</label><br/>
-            <input id="themevar30" name="themevar30" value="dashboard_columns" type="checkbox"><label for="themevar30" data-i18n="Dashboard in columns"> Display Dashboard in columns (screen width > 1200px)</label><br/><br/>
+            <input id="themevar30" name="themevar30" value="dashboard_columns" type="checkbox"><label for="themevar30" data-i18n="Dashboard in columns"> Display Dashboard in columns (screen width > 1200px)</label><br/>
+            <input id="themevar31" name="themevar31" value="dashboard_camera" type="checkbox"><label for="themevar31" data-i18n="Camera Preview on Dashboard"> Display Camera Preview on Dashboard</label><br/>
+            <br/>
             <p>Add your own logo. Leave empty for Machinon logo. Upload your logo to images folder in machinon theme folder (recomended size 200x30px).<br/></p>
             <label for="themevar17" data-i18n="logo"> Logo: </label><input id="themevar17" class="themevar17 ui-widget-content ui-corner-all" name="logo" value="logo.png" type="text"><br/>		
             <br/>


### PR DESCRIPTION
To use it:
- You need to attach a switch to your camera (create a switch then in Settings/Camera, add the switch to the camera)
-  Add the switch to the dashboard

Result:
![2019-04-19 15_10_06-Lyon – Brave](https://user-images.githubusercontent.com/12050155/56425559-20c69a80-62b5-11e9-8ccd-704321129f9a.png)
